### PR TITLE
Correct amino acid length for unfolding calculation

### DIFF
--- a/Analysis/(LUMICKS) Worm-like chain fitting protein unfolding data - AdK/Protein_Unfolding_AdK.ipynb
+++ b/Analysis/(LUMICKS) Worm-like chain fitting protein unfolding data - AdK/Protein_Unfolding_AdK.ipynb
@@ -339,7 +339,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, we need to put some initial guesses for the fit. We know the protein is going to be relatively short so we make a rough estimate of the order of magnitude. In general, the expected length of your fully unfolded protein can be calculated as the number of amino acids in the polypeptide chain multiplied by 0.356 nm per amino acid.\n",
+    "Again, we need to put some initial guesses for the fit. We know the protein is going to be relatively short so we make a rough estimate of the order of magnitude. In general, the expected length of your fully unfolded protein can be calculated as the number of amino acids in the polypeptide chain multiplied by 0.365 nm per amino acid.\n",
     "\n",
     "We also know that the persistence length of proteins is generally a lot lower than that of dsDNA. Therefore, we provide some rough bounds based on [2].\n",
     "\n",
@@ -395,7 +395,7 @@
     "\n",
     "If all went well, you should now be able to observe an estimated contour length of approximately 25 nm for the protein (variable `protein/Lc`).\n",
     "\n",
-    "This value can be used to obtain which fraction of the protein got unfolded (in terms of number of amino acids) by dividing it by 0.356nm/amino acid.\n",
+    "This value can be used to obtain which fraction of the protein got unfolded (in terms of number of amino acids) by dividing it by 0.365nm/amino acid.\n",
     "\n",
     "The obtained contour length corresponds to the actual increase of distance (tether length) caused by the protein domain(s) that have been unfolded."
    ]


### PR DESCRIPTION
The cited publication mentions 0.365nm as the length of a residue (amino acid)